### PR TITLE
MODEL&APP: allowed sdec and other sliders to set to 0

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -210,8 +210,10 @@ class Model:
 
     def run(self):
         self.env.process(self.generator_ed_arrivals())
-        self.env.process(self.generator_sdec_arrivals())
-        self.env.process(self.generator_other_arrivals())
+        if g.sdec_inter_visit !=0:
+            self.env.process(self.generator_sdec_arrivals())
+        if g.other_inter_visit !=0:
+            self.env.process(self.generator_other_arrivals())
         self.env.run(until=(g.sim_duration + g.warm_up_period))
         self.event_log = pd.DataFrame(self.event_log)
         self.event_log["run"] = self.run_number

--- a/app/sim_page.py
+++ b/app/sim_page.py
@@ -29,9 +29,9 @@ with st.sidebar:
     daily_ed_adm_slider = st.slider("Adjust daily demand for admission via ED",
                                     min_value=25, max_value=55, value=38)
     daily_sdec_adm_slider = st.slider("Adjust daily demand for admission via SDEC",
-                                    min_value=1, max_value=20, value=12)
+                                    min_value=0, max_value=20, value=12)
     daily_other_adm_slider = st.slider("Adjust daily demand for admission via other routes",
-                                    min_value=1, max_value=10, value=3)
+                                    min_value=0, max_value=10, value=3)
     num_nelbeds_slider = st.slider("Adjust number of non-elective beds",
                                 min_value=380, max_value=500, value=446)
     mean_los_slider = st.slider("Adjust mean inpatient LOS (hrs)",
@@ -59,8 +59,8 @@ g.mean_time_in_bed = (mean_los_slider * 60)
 g.sd_time_in_bed = (sd_los_slider * 60)
 g.number_of_nelbeds = num_nelbeds_slider
 g.ed_inter_visit = 1440/daily_ed_adm_slider
-g.sdec_inter_visit = 1440/daily_sdec_adm_slider #if daily_sdec_adm_slider != 0 else 0
-g.other_inter_visit = 1440/daily_other_adm_slider #if daily_other_adm_slider != 0 else 0
+g.sdec_inter_visit = 1440/daily_sdec_adm_slider if daily_sdec_adm_slider != 0 else 0
+g.other_inter_visit = 1440/daily_other_adm_slider if daily_other_adm_slider != 0 else 0
 g.number_of_runs = num_runs_slider
 
 tab1, tab_animate, tab2 = st.tabs(["Run Virtual Hospital", "View Animation", "Compare scenarios"])


### PR DESCRIPTION
Fixed the issue:

- if slider is set to 0, inter arrival time is set to 0 (no longer get a divide by 0 error)
https://github.com/Countess-of-Chester-Hospital-NHS-FT/Non-Elective-Flow-Simulation/blob/5b46d12fe909921a4d800cd84d059acb76a85ad6/app/sim_page.py#L62-L63
- if inter arrival time is set to 0, sdec and other generators are switched off (inside the run function of Model class)
https://github.com/Countess-of-Chester-Hospital-NHS-FT/Non-Elective-Flow-Simulation/blob/5b46d12fe909921a4d800cd84d059acb76a85ad6/app/model.py#L213-L216
